### PR TITLE
destroy streams explicitly

### DIFF
--- a/lib/cp.js
+++ b/lib/cp.js
@@ -12,6 +12,8 @@ exports = module.exports = function (src, dest, cb) {
   function next(err) {
     if (!done) {
       done = true;
+      read.destroy();
+      write.destroy();
       cb(err);
     }
   }


### PR DESCRIPTION
`.pipe()` doesn't do this. On any error one of the streams will remain open. 
